### PR TITLE
Changed fields named 'imei' to 'password'

### DIFF
--- a/WhatsAppApi/Base/WhatsAppBase.cs
+++ b/WhatsAppApi/Base/WhatsAppBase.cs
@@ -54,11 +54,11 @@ namespace WhatsAppApi
 
         protected BinTreeNodeWriter BinWriter;
 
-        protected void _constructBase(string phoneNum, string imei, string nick, bool debug, bool hidden)
+        protected void _constructBase(string phoneNum, string password, string nick, bool debug, bool hidden)
         {
             this.messageQueue = new List<ProtocolTreeNode>();
             this.phoneNumber = phoneNum;
-            this.password = imei;
+            this.password = password;
             this.name = nick;
             this.hidden = hidden;
             WhatsApp.DEBUG = debug;

--- a/WhatsAppApi/WhatsApp.cs
+++ b/WhatsAppApi/WhatsApp.cs
@@ -22,9 +22,9 @@ namespace WhatsAppApi
     /// </summary>
     public class WhatsApp : WhatsSendBase
     {
-        public WhatsApp(string phoneNum, string imei, string nick, bool debug = false, bool hidden = false)
+        public WhatsApp(string phoneNum, string password, string nick, bool debug = false, bool hidden = false)
         {
-            this._constructBase(phoneNum, imei, nick, debug, hidden);
+            this._constructBase(phoneNum, password, nick, debug, hidden);
         }
 
         public string SendMessage(string to, string txt)


### PR DESCRIPTION
Man, I changed the fields named 'imei' to 'password' because it's a common pitfall for many people that uses my package in NuGet gallery.
