### PR TITLE
Solved How to use the API behind a proxy

### DIFF
--- a/WhatsAppApi/Register/WhatsRegisterV2.cs
+++ b/WhatsAppApi/Register/WhatsRegisterV2.cs
@@ -13,6 +13,11 @@ namespace WhatsAppApi.Register
 {
     public static class WhatsRegisterV2
     {
+        static WhatsRegisterV2()
+        {
+            System.Net.WebRequest.DefaultWebProxy.Credentials = System.Net.CredentialCache.DefaultNetworkCredentials;
+        }
+
         public static string GenerateIdentity(string phoneNumber, string salt = "")
         {
             return (phoneNumber + salt).Reverse().ToSHAString();

--- a/WhatsAppApi/WhatsNetwork.cs
+++ b/WhatsAppApi/WhatsNetwork.cs
@@ -20,7 +20,7 @@ namespace WhatsAppApi
         /// <summary>
         /// The hostname of the whatsapp server
         /// </summary>
-        private readonly string whatsHost;
+        //private readonly string whatsHost;
 
         /// <summary>
         /// The port of the whatsapp server

--- a/WhatsAppPort/WhatsMessageHandler.cs
+++ b/WhatsAppPort/WhatsMessageHandler.cs
@@ -39,7 +39,7 @@ namespace WhatsAppPort
                 return;
 
             var jidSplit = mess.identifier_key.remote_jid.Split('@');
-            WhatsUser tmpWhatsUser = new WhatsUser(jidSplit[0], jidSplit[1], mess.identifier_key.serverName);
+            WhatsUser tmpWhatsUser = new WhatsUser(jidSplit[0], jidSplit[1], mess.identifier_key.serverNickname);
             User tmpUser = new User(jidSplit[0], jidSplit[1]);
             tmpUser.SetUser(tmpWhatsUser);
 


### PR DESCRIPTION
The API couldnt be used behind a proxy
I was getting error code (407) "Proxy Authentication Required."

I solved telling .NET to use default proxy configuration

static WhatsRegisterV2()
{
            System.Net.WebRequest.DefaultWebProxy.Credentials = System.Net.CredentialCache.DefaultNetworkCredentials;
}
The default behaviour of WebRequest.DefaultWebProxy is to use the same underlying settings as used by Internet Explorer.
